### PR TITLE
Refactor: Remove 'pronome' column from data and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,7 +86,7 @@ def process_files():
     
     return jsonify({
         "data": safe_data,
-        "columns": ["pronome", "nome", "cargo", "entidade", "observacoes", "autores"]
+        "columns": ["nome", "cargo", "entidade", "observacoes", "autores"]
     })
 
 @app.route('/export', methods=['POST'])
@@ -96,7 +96,7 @@ def export():
     if not isinstance(data, list):
         return jsonify({"error": "Formato inválido: esperado uma lista de objetos JSON"}), 400
 
-    column_order = ['autores', 'pronome', 'nome', 'cargo', 'entidade', 'observacoes']
+    column_order = ['autores', 'nome', 'cargo', 'entidade', 'observacoes']
     df = pd.DataFrame(data, columns=column_order)
     timestamp = time.strftime("%Y%m%d-%H%M%S")
     filename = f"convidados_{timestamp}.xlsx"

--- a/templates/index.html
+++ b/templates/index.html
@@ -209,7 +209,7 @@
       // Ensure we're using the array from the model response
       const items = Array.isArray(data[0]) ? data[0] : data;
       
-      const headers = ['Autores', 'Pronome', 'Nome', 'Cargo', 'Entidade', 'Observações'];
+      const headers = ['Autores', 'Nome', 'Cargo', 'Entidade', 'Observações'];
       let html = `<table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -220,7 +220,6 @@
           ${items.map(item => `
             <tr>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${item.autores || ''}</td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${item.pronome || ''}</td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${item.nome || ''}</td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${item.cargo || ''}</td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${item.entidade || ''}</td>


### PR DESCRIPTION
This commit removes the 'pronome' (treatment pronoun) column from the extracted data, the frontend table display, and the Excel export functionality.

- Modified `app.py` to exclude 'pronome' from data processing and export column lists.
- Updated `templates/index.html` to remove the 'pronome' header and corresponding cell from the results table.